### PR TITLE
Rework NanoApi::Model::Attributable#present_attributes

### DIFF
--- a/app/models/nano_api/feedback.rb
+++ b/app/models/nano_api/feedback.rb
@@ -23,7 +23,7 @@ module NanoApi
     end
 
     def save
-      NanoApi.client.send :post_raw, 'user_feedback_reports', :user_feedback_report => present_attributes
+      NanoApi.client.send :post_raw, 'user_feedback_reports', :user_feedback_report => existing_attributes
     rescue RestClient::UnprocessableEntity
       false
     ensure

--- a/lib/nano_api/model/attributable.rb
+++ b/lib/nano_api/model/attributable.rb
@@ -87,10 +87,10 @@ module NanoApi
         Hash[attribute_names.map { |name| [name, send(name)] }]
       end
 
-      def present_attributes
+      def existing_attributes
         Hash[attribute_names.map do |name|
           value = send(name)
-          [name, value] if value.present?
+          [name, value] unless value.respond_to?(:empty?) ? value.empty? : value.nil?
         end]
       end
 

--- a/spec/lib/nano_api/model/attributable_spec.rb
+++ b/spec/lib/nano_api/model/attributable_spec.rb
@@ -11,6 +11,8 @@ describe NanoApi::Model::Attributable do
       attribute :hello
       attribute :count, type: :integer, default: 10
       attribute(:calc, type: :integer) {2 + 3}
+      attribute(:big, type: :boolean) {false}
+      attribute(:title, type: :string){''}
 
       def initialize name = nil
         @attributes = self.class.initialize_attributes
@@ -21,15 +23,19 @@ describe NanoApi::Model::Attributable do
 
   context do
     subject{klass.new('world')}
-    its(:attributes){should == {"hello"=>nil, "count"=>10, "calc"=>5}}
-    its(:present_attributes){should == {"count"=>10, "calc"=>5}}
+    its(:attributes){should == {'hello'=>nil, 'count'=>10, 'calc'=>5, 'big'=>false, 'title'=>''}}
+    its(:existing_attributes){should == {'count'=>10, 'calc'=>5, 'big'=>false}}
     its(:name){should == 'world'}
     its(:hello){should be_nil}
     its(:count){should == 10}
     its(:calc){should == 5}
+    its(:big){should == false}
+    its(:title){should == ''}
     specify{expect{subject.hello = 'worlds'}.to change{subject.hello}.from(nil).to('worlds')}
     specify{expect{subject.count = 20}.to change{subject.count}.from(10).to(20)}
     specify{expect{subject.calc = 15}.to change{subject.calc}.from(5).to(15)}
+    specify{expect{subject.big = true}.to change{subject.big}.from(false).to(true)}
+    specify{expect{subject.title = 'sir'}.to change{subject.title}.from('').to('sir')}
   end
 
 end


### PR DESCRIPTION
1. rename it to #existing_attributes
2. return only non-empty and not nil attributes

For example:
some_object.attributes            => {'a'=> '', 'b'=>nil, 'c'=>5, 'd'=>false}
some_object.existing_attributes   => {'c'=>5, 'd'=>false}
