### PR TITLE
remove unloasable, coz ruby2+ror4

### DIFF
--- a/app/controllers/nano_api/application_controller.rb
+++ b/app/controllers/nano_api/application_controller.rb
@@ -1,7 +1,6 @@
 module NanoApi
   class ApplicationController < ::ApplicationController
     skip_before_filter :verify_authenticity_token
-    unloadable
     nano_extend
 
   protected

--- a/app/models/nano_api/search.rb
+++ b/app/models/nano_api/search.rb
@@ -1,7 +1,5 @@
 module NanoApi
   class Search
-    unloadable
-
     include NanoApi::Model
 
     attribute :origin_iata


### PR DESCRIPTION
Удалил метод `unloasable` в двух местах, что бы можно нормально изменять хост приложение и не получать следующую ошибку:

![Error](https://monosnap.com/image/t9Yen9I03WhpHi1aF4Rh7tXil.png)
